### PR TITLE
Prepare docker environment to build data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM php:7
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1
+
+RUN apt-get update
+
+RUN apt-get install -y wget libjpeg-dev libfreetype6-dev
+RUN apt-get install -y libmagick++-dev \
+libmagickwand-dev \
+libpq-dev \
+libfreetype6-dev \
+libjpeg62-turbo-dev \
+libpng-dev \
+libwebp-dev \
+libxpm-dev \
+libzip-dev
+
+RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/
+RUN docker-php-ext-install -j$(nproc) gd
+RUN docker-php-ext-install zip
+
+WORKDIR /app
+COPY composer.json ./
+RUN composer install
+COPY . .

--- a/README.md
+++ b/README.md
@@ -126,3 +126,12 @@ Composerによるインストールが可能です。
 ```
 composer require nojimage/local-gov-code-jp
 ```
+
+## Build
+
+docker-compose を利用してデータをビルドすることができます。
+
+```
+docker-compose build builder
+docker-compose run --rm builder composer build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  builder:
+    build:
+      context: .
+    volumes:
+      - ./index.json:/app/index.json:cached
+      - ./prefecture.json:/app/prefecture.json:cached
+      - ./cities.json:/app/cities.json:cached
+      - ./wards.json:/app/wards.json:cached
+      - ./jp_local_gov_codes.mysql.sql:/app/jp_local_gov_codes.mysql.sql:cached
+      - ./jp_local_gov_codes.sqlite.sql:/app/jp_local_gov_codes.sqlite.sql:cached


### PR DESCRIPTION
Docker を利用してデータをビルド (composer build) できるようにしました。
(背景: 地方公共団体データを利用する際、このリポジトリ上のjson形式がとても使いやすい形だったのですが、自分の手元にPHP環境がなく最新のデータに更新できなかったので、Docker を利用することで継続的に更新できるようにしたい)

実行方法は README.md に記載しました。

このPR単体だと諸々失敗しますが(メモリ不足 / wards.jsonが空配列になる など)、 https://github.com/nojimage/local-gov-code-jp/pull/5 の変更を取り込むことで、ビルドに成功し、同PRと同じようにデータが変更されることを確認しました。